### PR TITLE
Fix Tempo setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,6 @@ services:
       - ./tempo.yaml:/etc/tempo.yaml
     ports:
       - 8000:8000 # tempo
-      - 55681:55681 # otlp http
   pokespeare:
     build: .
     ports:

--- a/src/main.py
+++ b/src/main.py
@@ -26,7 +26,7 @@ trace.set_tracer_provider(
 )
 
 tracer.add_span_processor(
-    BatchSpanProcessor(OTLPSpanExporter(endpoint="http://tempo:55681", insecure=True))
+    BatchSpanProcessor(OTLPSpanExporter(endpoint="http://tempo:4317", insecure=True))
 )
 FastAPIInstrumentor.instrument_app(app, tracer_provider=tracer)
 

--- a/tempo.yaml
+++ b/tempo.yaml
@@ -1,5 +1,3 @@
-auth_enabled: false
-
 server:
   http_listen_port: 8000
 
@@ -8,7 +6,7 @@ distributor:
   receivers:
     otlp:
       protocols:
-        http:
+        grpc:
 
 storage:
   trace:


### PR DESCRIPTION
Changes:
- enable the OTLP/gRPC receiver in Tempo
- opentelemetry-python emits OTLP/gRPC, use the gRPC port instead
- trim unnecessary config and exposed ports